### PR TITLE
feat: make `result` return lambda to allow direct use with `type.submodule`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@ let
     }:
     path:
     let
-      result = if pipef == null then { imports = [ module ]; } else pipef (leaves path);
+      result = if pipef == null then module else pipef (leaves path);
 
       # module stays a function: callers may apply it as a module function, and
       # keeping it a lambda defers the tree read (`leaves path`) until module-eval
@@ -195,10 +195,13 @@ let
 
   functor =
     self: arg:
+
     if builtins.isFunction arg && builtins.functionArgs arg == { } then
       arg self # arg is a combinator pass the self import-tree obj
+    else if inModuleEval arg then
+      perform self.__config [ ] arg
     else
-      perform self.__config (if inModuleEval arg then [ ] else arg);
+      perform self.__config arg;
 
   callable =
     let

--- a/tests.nix
+++ b/tests.nix
@@ -255,6 +255,22 @@ in
       ];
     };
 
+    import-tree."test can be used in submodule" = {
+      expr =
+        (lib.evalModules {
+          modules = [
+            {
+              options.subModule = lib.mkOption {
+                type = lib.types.submodule (lit ./tree/modules/hello-option);
+              };
+              config.subModule = lit ./tree/modules/hello-world;
+            }
+          ];
+        }).config.subModule.hello;
+
+      expected = "world";
+    };
+
     leaves."test loads from hidden directory but excludes sub-hidden" = {
       expr = lit.leaves ./tree/a/b/_c;
       expected = [ ./tree/a/b/_c/d/e.nix ];

--- a/tests.nix
+++ b/tests.nix
@@ -189,14 +189,13 @@ in
       expected = [ ./tree/x/y.nix ];
     };
 
-    import-tree."test returns a module with a single imported nested module having leaves" = {
+    import-tree."test returns a lambda-module with nested module having leaves" = {
       expr =
         let
           oneElement = arr: if lib.length arr == 1 then lib.elemAt arr 0 else throw "Expected one element";
-          module = it ./tree/x;
-          inner = (oneElement module.imports) { inherit lib; };
+          module = it ./tree/x { inherit lib; };
         in
-        oneElement inner.imports;
+        oneElement module.imports;
       expected = ./tree/x/y.nix;
     };
 


### PR DESCRIPTION
ie. implement workaround described in https://github.com/NixOS/nixpkgs/issues/377575#issuecomment-4936090004

This also remove one level of module nesting, so could be seen as a simplification too.

Fix failing test introduced in [previous commit](https://github.com/denful/import-tree/pull/40/changes/53e5fd67f87348cb1381b79a50137013c77ca702).